### PR TITLE
rgb_html() function

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,7 +13,7 @@ Now, to make basic measurement::
 
     import tcs34725
     from machine import I2C, Pin
-    i2c = I2C(Pin(5), Pin(4))
+    i2c = I2C(-1, Pin(5), Pin(4))
     sensor = tcs34725.TCS34725(i2c)
     print(sensor.read())
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,7 +13,7 @@ Now, to make basic measurement::
 
     import tcs34725
     from machine import I2C, Pin
-    i2c = I2C(-1, Pin(5), Pin(4))
+    i2c = I2C(Pin(5), Pin(4))
     sensor = tcs34725.TCS34725(i2c)
     print(sensor.read())
 

--- a/docs/tcs34725.rst
+++ b/docs/tcs34725.rst
@@ -57,6 +57,11 @@ TCS34725
         the sensor. If the sensor was active, the library may still wait for
         the sensor to complete the measurement, if it's not ready.
 
+    .. method:: html_rgb(data)
+
+        Convert the 4-tuple values returned by ``read(raw=True)`` to a
+        4-tuple of 8 bit RGB values, and the HTML hex value.
+
     .. method:: threshold([cycles] [, min_value] [, max_value])
 
         Get or set the interrupt settings.

--- a/docs/tcs34725.rst
+++ b/docs/tcs34725.rst
@@ -57,11 +57,6 @@ TCS34725
         the sensor. If the sensor was active, the library may still wait for
         the sensor to complete the measurement, if it's not ready.
 
-    .. method:: html_rgb(data)
-
-        Convert the 4-tuple values returned by ``read(raw=True)`` to a
-        4-tuple of 8 bit RGB values, and the HTML hex value.
-
     .. method:: threshold([cycles] [, min_value] [, max_value])
 
         Get or set the interrupt settings.
@@ -91,3 +86,13 @@ TCS34725
         otherwise returns ``False``.
 
         When ``False`` is passed as an argument, clears the interrupt.
+
+.. function:: html_rgb(data)
+
+        Convert the 4-tuple values returned by ``read(raw=True)`` to a
+        3-tuple of 8 bit RGB values.
+
+.. function:: html_hex(data)
+
+        Convert the 4-tuple values returned by ``read(raw=True)`` to a
+        string of the HTML hex values for the color.

--- a/tcs34725.py
+++ b/tcs34725.py
@@ -123,22 +123,17 @@ class TCS34725:
         cct = 449.0 * n**3 + 3525.0 * n**2 + 6823.3 * n + 5520.33
         return cct, y
 
-    def html_rgb(self):
-        r, g, b, c = self.read(raw=True)
-        red = int((r/c) * 256)
-        green = int((g/c) * 256)
-        blue = int((b/c) * 256)
+    def html_rgb(self, data):
 
-        gammatable = {}
-        for x, y in enumerate(range(0, 256)):
-            x = x / 255
-            x = pow(x, 2.5)
-            x = x * 255
-            gammatable[y] = x
-        rgbhex = "{0:02x}{1:02x}{2:02x}".format(int(gammatable[red]),
-                                 int(gammatable[green]),
-                                 int(gammatable[blue]))
-        return rgbhex
+        r, g, b, c = data
+        red = pow((int((r/c) * 256) / 255), 2.5) * 255
+        green = pow((int((g/c) * 256) / 255), 2.5) * 255
+        blue = pow((int((b/c) * 256) / 255), 2.5) * 255
+
+        rgbhex = "{0:02x}{1:02x}{2:02x}".format(int(red),
+                                 int(green),
+                                 int(blue))
+        return red, green, blue, rgbhex
 
     def threshold(self, cycles=None, min_value=None, max_value=None):
         if cycles is None and min_value is None and max_value is None:

--- a/tcs34725.py
+++ b/tcs34725.py
@@ -123,6 +123,23 @@ class TCS34725:
         cct = 449.0 * n**3 + 3525.0 * n**2 + 6823.3 * n + 5520.33
         return cct, y
 
+    def html_rgb(self):
+        r, g, b, c = self.read(raw=True)
+        red = int((r/c) * 256)
+        green = int((g/c) * 256)
+        blue = int((b/c) * 256)
+
+        gammatable = {}
+        for x, y in enumerate(range(0, 256)):
+            x = x / 255
+            x = pow(x, 2.5)
+            x = x * 255
+            gammatable[y] = x
+        rgbhex = "{0:02x}{1:02x}{2:02x}".format(int(gammatable[red]),
+                                 int(gammatable[green]),
+                                 int(gammatable[blue]))
+        return rgbhex
+
     def threshold(self, cycles=None, min_value=None, max_value=None):
         if cycles is None and min_value is None and max_value is None:
             min_value = self._register16(_REGISTER_AILT)

--- a/tcs34725.py
+++ b/tcs34725.py
@@ -123,18 +123,6 @@ class TCS34725:
         cct = 449.0 * n**3 + 3525.0 * n**2 + 6823.3 * n + 5520.33
         return cct, y
 
-    def html_rgb(self, data):
-
-        r, g, b, c = data
-        red = pow((int((r/c) * 256) / 255), 2.5) * 255
-        green = pow((int((g/c) * 256) / 255), 2.5) * 255
-        blue = pow((int((b/c) * 256) / 255), 2.5) * 255
-
-        rgbhex = "{0:02x}{1:02x}{2:02x}".format(int(red),
-                                 int(green),
-                                 int(blue))
-        return red, green, blue, rgbhex
-
     def threshold(self, cycles=None, min_value=None, max_value=None):
         if cycles is None and min_value is None and max_value is None:
             min_value = self._register16(_REGISTER_AILT)
@@ -164,3 +152,17 @@ class TCS34725:
         if value:
             raise ValueError("interrupt can only be cleared")
         self.i2c.writeto(self.address, b'\xe6')
+
+
+def html_rgb(data):
+    r, g, b, c = data
+    red = pow((int((r/c) * 256) / 255), 2.5) * 255
+    green = pow((int((g/c) * 256) / 255), 2.5) * 255
+    blue = pow((int((b/c) * 256) / 255), 2.5) * 255
+    return red, green, blue
+
+def html_hex(data):
+    r, g, b = html_rgb(data)
+    return "{0:02x}{1:02x}{2:02x}".format(int(r),
+                             int(g),
+                             int(b))


### PR DESCRIPTION
* updated example doc to match current I2C initiator
* added rgb_html() function to return HTML hex representation of RGB values